### PR TITLE
Upgrade for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "illuminate/support": "^10.37|^11.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         }
     ],
     "require": {
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "doctrine/dbal": ">=2.10"
+        "php": "^8.2",
+        "illuminate/support": "^10.37|^11.0"
     },
     "autoload": {
         "psr-4": {
@@ -37,6 +37,6 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0"
+        "orchestra/testbench": "^8.0|^9.0"
     }
 }

--- a/src/Controller/DBMLController.php
+++ b/src/Controller/DBMLController.php
@@ -4,62 +4,58 @@ namespace Aphisitworachorch\Kacher\Controller;
 
 use Aphisitworachorch\Kacher\Traits\DBMLSyntaxTraits;
 use App\Http\Controllers\Controller;
-use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Illuminate\Support\Facades\DB;
+use Exception;
+use Illuminate\Support\Facades\Schema;
 
 class DBMLController extends Controller
 {
     use DBMLSyntaxTraits;
 
     /**
-     * @var AbstractSchemaManager
-     */
-    private $doctrine_instance;
-
-    /**
-     * @throws Exception
+     *
      */
     public function __construct ($custom_type=null)
     {
-        if ($custom_type != null){
+        /*if ($custom_type != null){
             foreach($custom_type as $ct => $key) {
                 DB::connection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping($ct, $key);
             }
-        }
-        DB::connection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
-        $this->doctrine_instance = DB::connection()->getDoctrineSchemaManager();
+        }*/
     }
 
     /**
-     * @throws Exception
+     *
      */
     private function getColumns($table_name, $type)
     {
         $columnInfo = [];
         if (!empty($table_name)) {
-            $instance = $this->doctrine_instance->listTableColumns ($table_name);
+            $instance = Schema::getColumns ($table_name);
             foreach($instance as $tableColumn){
                 if($type === "artisan"){
-                    $columnInfo[] = "name : {$tableColumn->getName ()}\n" . "type : {$tableColumn->getType ()->getName ()}\n";
+                    $columnInfo[] = "name : {$tableColumn['name']}\n" . "type : {$tableColumn['type']}\n";
                 }
                 if($type === "array"){
                     $special = [];
-                    if($this->isPrimaryKey ($tableColumn->getName (),$table_name) === "yes"){
+                    if($this->isPrimaryKey ($tableColumn['name'],$table_name) === "yes"){
                         $special[] = "pk";
                     }
-                    if($this->isUniqueKey ($tableColumn->getName (),$table_name) === "yes"){
+                    if($this->isUniqueKey ($tableColumn['name'],$table_name) === "yes"){
                         $special[] = "unique";
+                    }
+                    $length = '';
+                    if (preg_match('/.+\(([0-9]+)\)/', $tableColumn['type'], $matches)) {
+                        $length = $matches[1];
                     }
 
                     $columnInfo[] = [
-                        "name"=>$tableColumn->getName (),
-                        "type"=>$tableColumn->getType ()->getName (),
+                        "name"=>$tableColumn['name'],
+                        "type"=>$tableColumn['type'],
                         "special"=>$special,
-                        "note"=>$tableColumn->getComment (),
-                        "default_value"=>$tableColumn->getDefault (),
-                        "is_nullable"=>($tableColumn->getNotnull () ? "no" : "yes"),
-                        "length"=>$tableColumn->getLength ()
+                        "note"=>$tableColumn['comment'],
+                        "default_value"=>$tableColumn['default'],
+                        "is_nullable"=>($tableColumn['nullable'] ? "yes" : "no"),
+                        "length"=>$length
                     ];
                 }
             }
@@ -68,25 +64,25 @@ class DBMLController extends Controller
     }
 
     /**
-     * @throws Exception
+     *
      */
     private function getForeignKey($table_name, $type)
     {
         $columnInfo = [];
         if (!empty($table_name)) {
-            $instance = $this->doctrine_instance->listTableForeignKeys ($table_name);
+            $instance = Schema::getForeignKeys ($table_name);
             foreach($instance as $tableFK){
-                $fromColumns = implode(" | ",$tableFK->getColumns ());
-                $toColumns = implode(" | ",$tableFK->getForeignColumns ());
+                $fromColumns = implode(" | ",$tableFK['columns']);
+                $toColumns = implode(" | ",$tableFK['foreign_columns']);
                 if($type === "artisan"){
-                    $columnInfo[] = "[{$table_name}][{$fromColumns}] -> "."[$toColumns] of [{$tableFK->getForeignTableName ()}]";
+                    $columnInfo[] = "[{$table_name}][{$fromColumns}] -> "."[$toColumns] of [{$tableFK['foreign_table']}]";
                 }
                 if($type === "array"){
                     $columnInfo[] = [
                         "from"=>$table_name,
                         "name"=>$fromColumns,
                         "to"=>$toColumns,
-                        "table"=>$tableFK->getForeignTableName ()
+                        "table"=>$tableFK['foreign_table']
                     ];
                 }
             }
@@ -95,22 +91,22 @@ class DBMLController extends Controller
     }
 
     /**
-     * @throws Exception
+     *
      */
     private function getIndexes($table_name, $type)
     {
         $columnInfo = [];
         if (!empty($table_name)) {
-            $instance = $this->doctrine_instance->listTableIndexes ($table_name);
+            $instance = Schema::getIndexes ($table_name);
             foreach($instance as $tableIndex){
-                $unique = $tableIndex->isUnique () ? "yes" : "no";
-                $primary = $tableIndex->isPrimary () ? "yes" : "no";
+                $unique = $tableIndex['unique'] ? "yes" : "no";
+                $primary = $tableIndex['primary'] ? "yes" : "no";
                 if($type === "artisan"){
-                    $columns = implode(" | ",$tableIndex->getColumns ());
-                    $columnInfo[] = "name : {$tableIndex->getName ()}\n"."columns : {$columns}\n"."unique : {$unique}\n"."primary : {$primary}\n";
+                    $columns = implode(" | ",$tableIndex['columns']);
+                    $columnInfo[] = "name : {$tableIndex['name']}\n"."columns : {$columns}\n"."unique : {$unique}\n"."primary : {$primary}\n";
                 }
                 if($type === "array"){
-                    $columnInfo[] = ["name"=>$tableIndex->getName (),"columns"=>$tableIndex->getColumns (),"unique"=>$unique,"primary"=>$primary,"table"=>$table_name];
+                    $columnInfo[] = ["name"=>$tableIndex['name'],"columns"=>$tableIndex['columns'],"unique"=>$unique,"primary"=>$primary,"table"=>$table_name];
                 }
             }
         }
@@ -118,45 +114,45 @@ class DBMLController extends Controller
     }
 
     /**
-     * @throws Exception
+     *
      */
     private function isPrimaryKey($column, $table_name){
-        $primaryKeyInstance = $this->doctrine_instance->listTableIndexes ($table_name);
+        $primaryKeyInstance = Schema::getIndexes ($table_name);
         foreach($primaryKeyInstance as $tableIndex){
-            if($tableIndex->getColumns ()[0] === $column){
-                return $tableIndex->isPrimary () ? "yes" : "no";
+            if($tableIndex['name'] === $column){
+                return $tableIndex['primary'] ? "yes" : "no";
             }
         }
         return 0;
     }
 
     /**
-     * @throws Exception
+     *
      */
     private function isUniqueKey($column, $table_name){
-        $uniqueKeyInstance = $this->doctrine_instance->listTableIndexes ($table_name);
+        $uniqueKeyInstance = Schema::getIndexes ($table_name);
         foreach($uniqueKeyInstance as $tableIndex){
-            if($tableIndex->getColumns ()[0] === $column){
-                return $tableIndex->isUnique () ? "yes" : "no";
+            if($tableIndex['name'] === $column){
+                return $tableIndex['unique'] ? "yes" : "no";
             }
         }
         return 0;
     }
     /**
-     * @throws Exception
+     *
      */
     public function getDatabaseTable($type){
-        $tableName = $this->doctrine_instance->listTableNames();
+        $tableName = Schema::getTables();
         $data = [];
         if($tableName){
             if($type === "artisan"){
                 foreach($tableName as $tb){
                     $data[] = [
-                        "table_name" => $tb,
-                        "columns" => implode("\n",$this->getColumns ($tb,$type)),
-                        "foreign_key" => implode("\n",$this->getForeignKey ($tb,$type)),
-                        "indexes"=> implode("\n",$this->getIndexes ($tb,$type)),
-                        "comment"=> $this->doctrine_instance->listTableDetails($tb)->getComment()
+                        "table_name" => $tb['name'],
+                        "columns" => implode("\n",$this->getColumns ($tb['name'],$type)),
+                        "foreign_key" => implode("\n",$this->getForeignKey ($tb['name'],$type)),
+                        "indexes"=> implode("\n",$this->getIndexes ($tb['name'],$type)),
+                        "comment"=> $tb['comment']
                     ];
                 }
                 return $data;
@@ -164,11 +160,11 @@ class DBMLController extends Controller
             if($type === "array"){
                 foreach($tableName as $tb){
                     $data[] = [
-                        "table_name" => $tb,
-                        "columns" => $this->getColumns ($tb,$type),
-                        "foreign_key" => $this->getForeignKey ($tb,$type),
-                        "indexes"=> $this->getIndexes ($tb,$type),
-                        "comment"=> $this->doctrine_instance->listTableDetails($tb)->getComment()
+                        "table_name" => $tb['name'],
+                        "columns" => $this->getColumns ($tb['name'],$type),
+                        "foreign_key" => $this->getForeignKey ($tb['name'],$type),
+                        "indexes"=> $this->getIndexes ($tb['name'],$type),
+                        "comment"=> $tb['comment']
                     ];
                 }
                 return $data;
@@ -189,14 +185,12 @@ class DBMLController extends Controller
     {
         try{
             $table = $this->getDatabaseTable ("array");
-            $syntax = "";
-            $foreign = "";
-            $syntax .= $this->getDatabasePlatform();
+            $syntax = $this->getDatabasePlatform();
             foreach($table as $info){
                 if($info['table_name']){
                     $syntax .= $this->table ($info['table_name']) . $this->start ();
                     foreach($info['columns'] as $col){
-                        $syntax .= $this->column ($col['name'],$col['type'],$col['special'],$col['note'],$col['is_nullable'],$col['default_value'],$col['length']);
+                        $syntax .= $this->column ($col['name'],$col['type'],$col['special'],$col['note'],$col['is_nullable'],$col['default_value'] ?? null,'');
                     }
                     if($info['comment']){
                       $syntax .= "\n\tNote: '".$info['comment']."'\n";

--- a/src/Traits/DBMLSyntaxTraits.php
+++ b/src/Traits/DBMLSyntaxTraits.php
@@ -29,7 +29,7 @@ trait DBMLSyntaxTraits
 
     public function index()
     {
-        return "\n\tindexes";
+        return "\n\tindexes ";
     }
 
     public function start()
@@ -98,11 +98,15 @@ trait DBMLSyntaxTraits
         }
 
         if($default){
-            $annotation[] = "default: '$default'";
+            $annotation[] = "default: " . ((str_starts_with($default, "'") && str_ends_with($default, "'")) ? $default : "'" . $default . "'");
         }
 
         if($length){
             $len_annotate = "($length)";
+        }
+
+        if (str_contains($type, ' ')) {
+            $type = '"'.$type.'"';
         }
 
         $results = implode(",",$annotation);


### PR DESCRIPTION
Due to the removal of DBAL in Laravel 11 (see [Laravel 11 Upgrade Guide](https://laravel.com/docs/11.x/upgrade#doctrine-dbal-removal)), I have rebuilt the generation of DBML using the native Laravel 11 methods.

All the methods I used were added in various versions of Laravel 10. Therefore, this is a **breaking change** and will not work with Laravel versions prior to v10.37. Below is a list of the methods and their corresponding versions:

| Method | Available Since Version | Merge Request |
|--------|--------------------------|---------------|
| getColumns() | v10.30 | [#48357](https://github.com/laravel/framework/pull/48357) |
| getTables() | v10.34 | [#49020](https://github.com/laravel/framework/pull/49020) |
| getIndexes() | v10.37 | [#49204](https://github.com/laravel/framework/pull/49204) |
| getForeignKeys() | v10.37 | [#49264](https://github.com/laravel/framework/pull/49264) |

I have set the minimum version in the composer.json to v10.37. If you prefer to set the minimum version to v11 only, please let me know.

Due to these breaking changes, this update might require a new release of the package.

For full backwards compatibility, it should be possible to add a switch to use either the native methods or the old DBAL methods. If you prefer this, let me know.

Fixes #6 